### PR TITLE
Entferne veraltete Kommunikations-Kanäle

### DIFF
--- a/src/SpaceApiEntry.py
+++ b/src/SpaceApiEntry.py
@@ -13,7 +13,6 @@ class SpaceApiEntry:
         )
         entry.add_contact("email", "kontakt@netz39.de", is_issue_channel=True)
         entry.add_contact("ml", "list@netz39.de", is_issue_channel=True)
-        entry.add_contact("jabber", "lounge@conference.jabber.n39.eu")
         entry.add_contact("discord", "https://discord.netz39.de/")
         entry.add_contact("github", "https://github.com/Netz39")
         entry.add_contact("mastodon", "https://machteburch.social/@netz39")

--- a/src/SpaceApiEntry.py
+++ b/src/SpaceApiEntry.py
@@ -12,7 +12,6 @@ class SpaceApiEntry:
             icon_closed="https://www.netz39.de/closed.png"
         )
         entry.add_contact("email", "kontakt@netz39.de", is_issue_channel=True)
-        entry.add_contact("twitter", "@netz39", is_issue_channel=True)
         entry.add_contact("ml", "list@netz39.de", is_issue_channel=True)
         entry.add_contact("jabber", "lounge@conference.jabber.n39.eu")
         entry.add_contact("discord", "https://discord.netz39.de/")


### PR DESCRIPTION
* Twitter: heißt nun X und IMHO sollten wir diese Plattform nicht mehr unterstützen. Es ist sinnvoll, den Account zu behalten, damit niemand Blödsinn mit dem Namen macht
* Jabber: Es wäre schön gewesen, wenn diese Plattform sich durchgesetzt hätte - hat sie aber leider nicht, und auch mit (selbstgemachten) Gründen. Die Community ist dort nicht vertreten, auch wenn einzelne Leute dort vielleicht rumhängen, und ich halte es nicht für sinnvoll, diesen Kanal  für die Kommunikation mit der Community bekanntzugeben.

Die Anpassungen spiegeln den Status Quo der Community wider.