### PR TITLE
:arrow_up: Bump tornado to 6.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest==7.1.2
 pytest-asyncio==0.19.0
-tornado==6.4.2
+tornado==6.5.0
 isodate==0.6.0
 paho-mqtt==2.1.0


### PR DESCRIPTION
This fixes https://github.com/netz39/Netz39SpaceAPI-Service/security/dependabot/2