### PR TITLE
Fix RSS and ical URIs

### DIFF
--- a/src/SpaceApiEntry.py
+++ b/src/SpaceApiEntry.py
@@ -22,7 +22,7 @@ class SpaceApiEntry:
         entry.add_contact("instagram", "https://www.instagram.com/netz_39/")
 
         entry.add_feed("blog", "rss", "https://www.netz39.de/feed.xml")
-        entry.add_feed("calendar", "ical", "https://www.netz39.de/feed/eo-events/")
+        entry.add_feed("calendar", "ical", "https://www.netz39.de/feed/eo-events/events.ics")
 
         return entry
 


### PR DESCRIPTION
This pull request updates the URLs for the blog and calendar feeds in the `create_netz39` function to reflect changes on the web site.

Fixes #13 

* [`src/SpaceApiEntry.py`](diffhunk://#diff-7379d4fa85004cfa8e161e20a39dc1d719e8fb6bc7538651844a393d816beb6cL24-R25): Updated the blog feed URL to use `feed.xml` instead of `feed/` and the calendar feed URL to use `events.ics` instead of `feed/eo-events/`.