### PR TITLE
Set up Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -39,20 +39,20 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Install python
       uses: actions/setup-python@v5
       with:
-          python-version: '3.12'
+          python-version: '3.13'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check-out"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: "Generate release changelog"
@@ -26,7 +26,7 @@ jobs:
         id: get-version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: "Create GitHub release"
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
           name: "${{ steps.get-version.outputs.VERSION }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD . /git/
 RUN git describe --always --dirty > /git-version.txt
 
 
-FROM python:3.12
+FROM python:3.13
 
 EXPOSE 8080
 HEALTHCHECK --interval=10s CMD curl --fail http://localhost:8080/health || exit 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest==8.4.2
 pytest-asyncio==1.2.0
 tornado==6.5.2
-isodate==0.6.0
+isodate==0.7.2
 paho-mqtt==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pytest==7.1.2
-pytest-asyncio==0.19.0
+pytest==8.4.2
+pytest-asyncio==1.2.0
 tornado==6.5.0
 isodate==0.6.0
 paho-mqtt==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest==8.4.2
 pytest-asyncio==1.2.0
-tornado==6.5.0
+tornado==6.5.2
 isodate==0.6.0
 paho-mqtt==2.1.0


### PR DESCRIPTION
This PR adds a new `.github/dependabot.yml` configuration to enable weekly automated updates dependencies, labeled as "dependencies".

The existing workflows have been updated to the latest viable release.

> [!CAUTION]
> When the Dependabot PR for an update to  `janheinrichmerker/action-github-changelog-generator@v2.4` is created, it must be set to *ignore the minor release*, as **version 2.4 contains a bug**.