### PR TITLE
Generate Artifact attestations for Docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -67,3 +67,13 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        # The digest is only available after a push
+        # Limit to tagged releases to avoid attesting every single merge to main
+        if: startsWith(github.ref, 'refs/tags/v') && steps.push.outputs.digest != ''
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
This PR updates the docker-image workflow to the latest action versions and adds an action to generate artifact attestations for any versioned Docker image that is uploaded to Docker Hub.
