### PR TITLE
Fix image name syntax in Docker workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}//spaceapi-service
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/spaceapi-service
   TARGET_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:


### PR DESCRIPTION
This pull request makes a small correction to the Docker image name in the GitHub Actions workflow to ensure the image is pushed to the correct repository.

* Fixed a typo in the `IMAGE_NAME` environment variable in `.github/workflows/docker-image.yml` by replacing a double slash with a single slash, ensuring the Docker image is correctly named and published.